### PR TITLE
Update CWL paths

### DIFF
--- a/cwl-tools/Comet/Comet.cwl
+++ b/cwl-tools/Comet/Comet.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 baseCommand: comet
 label: comet-ms

--- a/cwl-tools/GOEnrichment/GOEnrichment.cwl
+++ b/cwl-tools/GOEnrichment/GOEnrichment.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 label: GOEnrichment.cwl
 requirements:

--- a/cwl-tools/MSFragger/MSFragger.cwl
+++ b/cwl-tools/MSFragger/MSFragger.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 baseCommand: msfragger
 label: msfragger

--- a/cwl-tools/MS_Amanda/MS_Amanda.cwl
+++ b/cwl-tools/MS_Amanda/MS_Amanda.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 label: ms_amanda
 class: CommandLineTool
 baseCommand: ["/bin/bash", "-c"]

--- a/cwl-tools/PeptideProphet/PeptideProphet.cwl
+++ b/cwl-tools/PeptideProphet/PeptideProphet.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 baseCommand: ["xinteract", "-Noutput_interact.pep.xml" , "-p0.95" , "-l7" , "-PPM"]
 label: PeptideProphet.cwl

--- a/cwl-tools/ProteinProphet/ProteinProphet.cwl
+++ b/cwl-tools/ProteinProphet/ProteinProphet.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 baseCommand: "ProteinProphet"
 label: ProteinProphet.cwl

--- a/cwl-tools/StPeter/StPeter.cwl
+++ b/cwl-tools/StPeter/StPeter.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 baseCommand: "StPeter"
 label: StPeter.cwl

--- a/cwl-tools/XTandem/XTandem.cwl
+++ b/cwl-tools/XTandem/XTandem.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 label: XTandem.cwl
 baseCommand: ["mkdir", "-p", "/tmp/XTandem"]

--- a/cwl-tools/gProfiler/gProfiler.cwl
+++ b/cwl-tools/gProfiler/gProfiler.cwl
@@ -1,4 +1,4 @@
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 baseCommand: ["bash"]
 requirements:

--- a/cwl-tools/idconvert/idconvert_to_mzIdentML.cwl
+++ b/cwl-tools/idconvert/idconvert_to_mzIdentML.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 label: idconvert.cwl
 

--- a/cwl-tools/idconvert/idconvert_to_pepXML.cwl
+++ b/cwl-tools/idconvert/idconvert_to_pepXML.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 label: idconvert.cwl
 

--- a/cwl-tools/mzRecal/mzRecal.cwl
+++ b/cwl-tools/mzRecal/mzRecal.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 label: mzRecal.cwl
 requirements:

--- a/cwl-tools/protXml2IdList/protXml2IdList.cwl
+++ b/cwl-tools/protXml2IdList/protXml2IdList.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-cwlVersion: v1.0
+cwlVersion: v1.2
 class: CommandLineTool
 baseCommand: ["xmllint", "--xpath",  "//*[local-name()='protein']/@protein_name"]
 requirements:

--- a/domains/template-domain/config.json
+++ b/domains/template-domain/config.json
@@ -3,7 +3,7 @@
   "ontologyPrefixIRI": "http://edamontology.org/",
   "toolsTaxonomyRoot": "operation_0004",
   "dataDimensionsTaxonomyRoots": ["data_0006", "format_1915"],
-  "tool_annotations_path": "https://raw.githubusercontent.com/Workflomics/containers/main/domains/template-domain/bio.tools.json",
+  "tool_annotations_path": "https://raw.githubusercontent.com/Workflomics/containers/main/domains/template-domain/tools.json",
   "constraints_path": "https://raw.githubusercontent.com/Workflomics/containers/main/domains/template-domain/constraints.json",
   "strict_tool_annotations": "true",
   "timeout_sec": "120",


### PR DESCRIPTION
This pull request updates the `cwlVersion` in several CWL tool files from `v1.0` to `v1.2` and modifies a configuration file to update a URL path to the correct one. 

The changes ensure that the CWL version used aligns with our guidelines and that the template domain is well annotated.
