### PR TITLE
Include tests for magic

### DIFF
--- a/cwl-tools/imagemagick/imagemagick-jpg-png.cwl
+++ b/cwl-tools/imagemagick/imagemagick-jpg-png.cwl
@@ -17,7 +17,7 @@ requirements:
 inputs:
   magick_in_1:
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3579"  # JPG
+    format: http://edamontology.org/format_3579  # JPG
     inputBinding:
       position: 1
       valueFrom: $(self.path)
@@ -25,6 +25,6 @@ inputs:
 outputs:
   magick_out_1: 
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3603"  # PNG
+    format: http://edamontology.org/format_3603  # PNG
     outputBinding:
       glob: "imagemagick_output.png"

--- a/cwl-tools/imagemagick/imagemagick-jpg-tiff.cwl
+++ b/cwl-tools/imagemagick/imagemagick-jpg-tiff.cwl
@@ -17,7 +17,7 @@ requirements:
 inputs:
   magick_in_1:
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3579"  # JPG
+    format: http://edamontology.org/format_3579  # JPG
     inputBinding:
       position: 1
       valueFrom: $(self.path)
@@ -25,6 +25,6 @@ inputs:
 outputs:
   magick_out_1: 
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3752"  # TIFF
+    format: http://edamontology.org/format_3752  # TIFF
     outputBinding:
       glob: "imagemagick_output.tiff"

--- a/cwl-tools/imagemagick/imagemagick-png-jpg.cwl
+++ b/cwl-tools/imagemagick/imagemagick-png-jpg.cwl
@@ -17,7 +17,7 @@ requirements:
 inputs:
   magick_in_1:
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3603"  # PNG
+    format: http://edamontology.org/format_3603  # PNG
     inputBinding:
       position: 1
       valueFrom: $(self.path)
@@ -25,6 +25,6 @@ inputs:
 outputs:
   magick_out_1: 
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3579"  # JPG
+    format: http://edamontology.org/format_3579  # JPG
     outputBinding:
       glob: "imagemagick_output.jpg"

--- a/cwl-tools/imagemagick/imagemagick-png-tiff.cwl
+++ b/cwl-tools/imagemagick/imagemagick-png-tiff.cwl
@@ -17,7 +17,7 @@ requirements:
 inputs:
   magick_in_1:
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3603"  # PNG
+    format: http://edamontology.org/format_3603  # PNG
     inputBinding:
       position: 1
       valueFrom: $(self.path)
@@ -25,6 +25,6 @@ inputs:
 outputs:
   magick_out_1: 
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3752"  # TIFF
+    format: http://edamontology.org/format_3752  # TIFF
     outputBinding:
       glob: "imagemagick_output.tiff"

--- a/cwl-tools/imagemagick/imagemagick-tiff-jpg.cwl
+++ b/cwl-tools/imagemagick/imagemagick-tiff-jpg.cwl
@@ -17,7 +17,7 @@ requirements:
 inputs:
   magick_in_1:
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3752"  # TIFF
+    format: http://edamontology.org/format_3752  # TIFF
     inputBinding:
       position: 1
       valueFrom: $(self.path)
@@ -25,6 +25,6 @@ inputs:
 outputs:
   magick_out_1: 
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3579"  # JPG
+    format: http://edamontology.org/format_3579  # JPG
     outputBinding:
       glob: "imagemagick_output.jpg"

--- a/cwl-tools/imagemagick/imagemagick-tiff-png.cwl
+++ b/cwl-tools/imagemagick/imagemagick-tiff-png.cwl
@@ -17,7 +17,7 @@ requirements:
 inputs:
   magick_in_1:
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3752"  # TIFF
+    format: http://edamontology.org/format_3752  # TIFF
     inputBinding:
       position: 1
       valueFrom: $(self.path)
@@ -25,6 +25,6 @@ inputs:
 outputs:
   magick_out_1: 
     type: File
-    format: "https://edamontology.github.io/edam-browser/format_3603"  # PNG
+    format: http://edamontology.org/format_3603  # PNG
     outputBinding:
       glob: "imagemagick_output.png"

--- a/cwl-tools/imagemagick/test/input-jpg.yml
+++ b/cwl-tools/imagemagick/test/input-jpg.yml
@@ -1,0 +1,4 @@
+magick_in_1:
+  class: File
+  format: http://edamontology.org/format_3579
+  path: https://raw.githubusercontent.com/Workflomics/DemoKit/refs/heads/main/data/inputs/msi-example.jpg

--- a/cwl-tools/imagemagick/test/input-png.yml
+++ b/cwl-tools/imagemagick/test/input-png.yml
@@ -1,0 +1,4 @@
+magick_in_1:
+  class: File
+  format: http://edamontology.org/format_3603
+  path: https://raw.githubusercontent.com/Workflomics/DemoKit/refs/heads/main/data/inputs/msi-example.png

--- a/cwl-tools/imagemagick/test/input-tiff.yml
+++ b/cwl-tools/imagemagick/test/input-tiff.yml
@@ -1,0 +1,4 @@
+magick_in_1:
+  class: File
+  format: http://edamontology.org/format_3752
+  path: https://raw.githubusercontent.com/Workflomics/DemoKit/refs/heads/main/data/inputs/msi-example.tiff

--- a/cwl-tools/imagemagick/test/run-cwl.sh
+++ b/cwl-tools/imagemagick/test/run-cwl.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+cwltool --outdir output ../imagemagick-jpg-png.cwl ./input-jpg.yml
+
+cwltool --outdir output ../imagemagick-jpg-tiff.cwl ./input-jpg.yml
+
+cwltool --outdir output ../imagemagick-png-jpg.cwl ./input-png.yml
+
+cwltool --outdir output ../imagemagick-png-tiff.cwl ./input-png.yml
+
+cwltool --outdir output ../imagemagick-tiff-jpg.cwl ./input-tiff.yml
+
+cwltool --outdir output ../imagemagick-tiff-png.cwl ./input-tiff.yml
+
+


### PR DESCRIPTION
The PR introduces tests for the magic `cwl` scripts. 
- I have added the 3 input.yml files for each type (linking to [demokit](https://github.com/Workflomics/DemoKit/tree/main/data/inputs) repo where I uploaded 3 example images)
- I have added a script `run-cwl.sh` that will call be automatically executed when you make a PR into `main` (there is a GitHub action that executes `test/run-cwl.sh` for each tool if it exists)

This will ensure that the docker images can be pulled and executed on any machine. You can use this template to test the other tools.

Finally, I updated the EDAM types and formats URIs. Instead of using 
`"https://edamontology.github.io/edam-browser/format_1929"  # JPG`
we have to use:
`http://edamontology.org/format_1929  # PNG` - the correct EDAM URI (you can see URI as the ID of the term in the ontology). 

For example. when you open the [EDAM Browser for FASTA](https://edamontology.github.io/edam-browser/#format_1929) and click to copy URI (see Fig) you will get `http://edamontology.org/format_1929`
![Screenshot 2024-11-14 at 14 16 48](https://github.com/user-attachments/assets/3dd9e12e-4b1b-44ad-aeeb-fe2581b6d08f)
